### PR TITLE
Add missing SIRF C++ functionality via wrapper

### DIFF
--- a/test_functionality.py
+++ b/test_functionality.py
@@ -5,8 +5,16 @@ from matplotlib import pyplot as plt
 SIRFpath='D:/SIRF/SIRFbuild/INSTALL/'
 #SIRFpath='/home/sirfuser/devel/install'
 c= ala.STIRImageData(SIRFpath + '/share/SIRF-3.1/data/examples/PET/test_image_PM_QP_6.hv') 
+
+# test creating a STIRImageData object with given dimensions etc
+c= ala.STIRImageData()
+c.initialise((40,5,6),(1,1,1));
+print(c.get_geom_info_sptr().get_info())
+
 ctest= PET.ImageData(SIRFpath + '/share/SIRF-3.1/data/examples/PET/test_image_PM_QP_6.hv') 
 im= ala.STIRImageData(SIRFpath + '/share/SIRF-3.1/data/examples/PET/test_image_PM_QP_6.hv') 
+print(im.get_geom_info_sptr().get_info())
+
 b= ala.PETAcquisitionDataInFile(SIRFpath + '/share/SIRF-3.1/data/examples/PET/Utahscat600k_ca_seg4.hs')
 btest= PET.AcquisitionData(SIRFpath + '/share/SIRF-3.1/data/examples/PET/Utahscat600k_ca_seg4.hs')
 


### PR DESCRIPTION
- `STIRImageData::initialise` allows specifying an image of different size
- `PETAcquisitionDataInMemory(scanner_name, ...)` allows constructing data for a given scanner
- `PETAcquisitionModelUsingRayTracingMatrix` allows simulating data

I've also added `get_info()` functions to be able to check (via a string) if data was initialised properly. (Note that `STIRImageData`'s `get_info()` is affected by https://github.com/SyneRBI/SIRF/issues/791, and therefore seems to report the wrong order, but thishas nothing to do with this project)